### PR TITLE
style: Make active navigation tab brighter

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -135,7 +135,7 @@ body {
   background: rgba(102, 126, 234, .1);
 }
 .nav button.active {
-  color: var(--primary);
+  color: var(--secondary);
   font-weight: 600;
 }
 .nav button.active::after {


### PR DESCRIPTION
This commit changes the color of the active navigation tab to a brighter color to improve legibility.

The `color` property for the `.nav button.active` rule was changed from `var(--primary)` to `var(--secondary)`.