### PR TITLE
fix: Improve website responsiveness and table layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -64,7 +64,7 @@ body {
   will-change:width;transform:translateZ(0);
 }
 
-.container{max-width:min(1000px,100vw - var(--space-xl));margin:0 auto;padding:var(--space-xl)}
+.container{max-width:min(1400px,100vw - var(--space-xl));margin:0 auto;padding:var(--space-xl)}
 
 .card{
   background:var(--bg-white);border-radius:var(--radius);box-shadow:var(--shadow-lg);
@@ -269,12 +269,9 @@ body {
 
 /* HP Parts Table Styles */
 .hp-parts-table {
-  width: 100%;
   border-collapse: collapse;
   margin-top: 20px;
   font-size: var(--font-sm);
-  overflow-x: auto;
-  display: block;
 }
 
 .hp-parts-table th,
@@ -282,7 +279,7 @@ body {
   padding: 12px 15px;
   border: 1px solid var(--border);
   text-align: left;
-  white-space: nowrap;
+  word-break: break-word;
 }
 
 .hp-parts-table th {
@@ -298,4 +295,11 @@ body {
 .hp-parts-table tbody tr:hover {
   background-color: #f1f1f1;
   color: var(--text-dark);
+}
+
+@media (max-width: 768px) {
+  .table-wrapper {
+    overflow-x: auto;
+    display: block;
+  }
 }

--- a/dist/script.js
+++ b/dist/script.js
@@ -150,9 +150,13 @@ document.addEventListener('DOMContentLoaded', () => {
                     tbody.appendChild(row);
                 });
                 table.appendChild(tbody);
+                // Create a wrapper for the table to handle responsive scrolling
+                const tableWrapper = document.createElement('div');
+                tableWrapper.classList.add('table-wrapper');
+                tableWrapper.appendChild(table);
                 // Clear existing content and append table
                 entryDiv.innerHTML = '<h3>HP Parts List Database</h3>';
-                entryDiv.appendChild(table);
+                entryDiv.appendChild(tableWrapper);
             }
             catch (error) {
                 console.error('Error fetching or displaying HP parts data:', error);

--- a/ts/script.ts
+++ b/ts/script.ts
@@ -154,9 +154,14 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             table.appendChild(tbody);
 
+            // Create a wrapper for the table to handle responsive scrolling
+            const tableWrapper = document.createElement('div');
+            tableWrapper.classList.add('table-wrapper');
+            tableWrapper.appendChild(table);
+
             // Clear existing content and append table
             entryDiv.innerHTML = '<h3>HP Parts List Database</h3>';
-            entryDiv.appendChild(table);
+            entryDiv.appendChild(tableWrapper);
 
         } catch (error) {
             console.error('Error fetching or displaying HP parts data:', error);


### PR DESCRIPTION
- Increases the max-width of the main container to 1400px to better utilize space on ultrawide monitors.
- Adjusts the HP parts table styling to be responsive.
- Wraps the table in a div that allows for horizontal scrolling on mobile devices, preventing page overflow.
- Removes the `white-space: nowrap` property to allow text to wrap in table cells, improving readability.