### PR TITLE
revert: Revert responsive design changes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -64,7 +64,7 @@ body {
   will-change:width;transform:translateZ(0);
 }
 
-.container{max-width:min(1400px,100vw - var(--space-xl));margin:0 auto;padding:var(--space-xl)}
+.container{max-width:min(1000px,100vw - var(--space-xl));margin:0 auto;padding:var(--space-xl)}
 
 .card{
   background:var(--bg-white);border-radius:var(--radius);box-shadow:var(--shadow-lg);
@@ -269,9 +269,12 @@ body {
 
 /* HP Parts Table Styles */
 .hp-parts-table {
+  width: 100%;
   border-collapse: collapse;
   margin-top: 20px;
   font-size: var(--font-sm);
+  overflow-x: auto;
+  display: block;
 }
 
 .hp-parts-table th,
@@ -279,7 +282,7 @@ body {
   padding: 12px 15px;
   border: 1px solid var(--border);
   text-align: left;
-  word-break: break-word;
+  white-space: nowrap;
 }
 
 .hp-parts-table th {
@@ -295,11 +298,4 @@ body {
 .hp-parts-table tbody tr:hover {
   background-color: #f1f1f1;
   color: var(--text-dark);
-}
-
-@media (max-width: 768px) {
-  .table-wrapper {
-    overflow-x: auto;
-    display: block;
-  }
 }

--- a/dist/script.js
+++ b/dist/script.js
@@ -150,13 +150,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     tbody.appendChild(row);
                 });
                 table.appendChild(tbody);
-                // Create a wrapper for the table to handle responsive scrolling
-                const tableWrapper = document.createElement('div');
-                tableWrapper.classList.add('table-wrapper');
-                tableWrapper.appendChild(table);
                 // Clear existing content and append table
                 entryDiv.innerHTML = '<h3>HP Parts List Database</h3>';
-                entryDiv.appendChild(tableWrapper);
+                entryDiv.appendChild(table);
             }
             catch (error) {
                 console.error('Error fetching or displaying HP parts data:', error);

--- a/ts/script.ts
+++ b/ts/script.ts
@@ -154,14 +154,9 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             table.appendChild(tbody);
 
-            // Create a wrapper for the table to handle responsive scrolling
-            const tableWrapper = document.createElement('div');
-            tableWrapper.classList.add('table-wrapper');
-            tableWrapper.appendChild(table);
-
             // Clear existing content and append table
             entryDiv.innerHTML = '<h3>HP Parts List Database</h3>';
-            entryDiv.appendChild(tableWrapper);
+            entryDiv.appendChild(table);
 
         } catch (error) {
             console.error('Error fetching or displaying HP parts data:', error);


### PR DESCRIPTION
This reverts the commit that attempted to make the website more responsive.

The changes were not satisfactory to the user, as they made the HP Parts List Database section look "squished". This commit restores the previous state, where the table is horizontally scrollable.