### PR TITLE
feat: Make main content full width

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -64,7 +64,7 @@ body {
   will-change:width;transform:translateZ(0);
 }
 
-.container{max-width:min(1000px,100vw - var(--space-xl));margin:0 auto;padding:var(--space-xl)}
+.container{max-width:100%;margin:0 auto;padding:var(--space-xl)}
 
 .card{
   background:var(--bg-white);border-radius:var(--radius);box-shadow:var(--shadow-lg);


### PR DESCRIPTION
This change modifies the .container class in css/styles.css to have a max-width of 100%.

This allows the main content area to stretch to the full width of the browser window, making the layout responsive and removing the empty space on the left and right sides of the content on larger screens.