### PR TITLE
Fix: Defer loading of HP parts table to prevent blocking

### DIFF
--- a/dist/script.js
+++ b/dist/script.js
@@ -208,7 +208,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
-    loadAndDisplayHPParts();
+    setTimeout(() => loadAndDisplayHPParts(), 0);
     // Web3 functionality
     const connectWalletBtn = document.getElementById('connectWalletBtn');
     let provider = null;

--- a/ts/script.ts
+++ b/ts/script.ts
@@ -219,7 +219,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    loadAndDisplayHPParts();
+    setTimeout(() => loadAndDisplayHPParts(), 0);
 
     // Web3 functionality
     const connectWalletBtn = document.getElementById('connectWalletBtn') as HTMLButtonElement | null;


### PR DESCRIPTION
The `loadAndDisplayHPParts` function was being called directly within the `DOMContentLoaded` event listener, which could block the main thread while the data was being fetched and the table was being rendered. This could make the website feel "frozen" on initial load.

This change wraps the call to `loadAndDisplayHPParts` in a `setTimeout` with a delay of 0. This defers the execution of the function until after the main thread has finished its current work, improving the perceived performance of the site.