### PR TITLE
feat: Add loading indicator for HP parts table

### DIFF
--- a/dist/script.js
+++ b/dist/script.js
@@ -40,6 +40,7 @@ window.addEventListener('scroll', () => {
 }, { passive: true });
 // Enhanced hover effects for interactive elements
 document.addEventListener('DOMContentLoaded', () => {
+    loadAndDisplayHPParts();
     // Profile image interaction
     const profileImage = document.querySelector('.profile-image');
     if (profileImage) {
@@ -160,9 +161,11 @@ document.addEventListener('DOMContentLoaded', () => {
             const projectsSection = document.getElementById('projects');
             if (!projectsSection)
                 return;
-            const entryDiv = projectsSection.querySelector('.entry');
+            const entryDiv = projectsSection.querySelector('#hp-parts-entry');
             if (!entryDiv)
                 return;
+            // Add a loading message immediately
+            entryDiv.innerHTML = '<h3>HP Parts List Database</h3><p>Loading data...</p>';
             try {
                 const response = yield fetch('data/hp_parts.json');
                 if (!response.ok) {
@@ -198,7 +201,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     tbody.appendChild(row);
                 });
                 table.appendChild(tbody);
-                // Clear existing content and append table
+                // Clear the loading message and append the table
                 entryDiv.innerHTML = '<h3>HP Parts List Database</h3>';
                 entryDiv.appendChild(table);
             }
@@ -208,7 +211,6 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
-    setTimeout(() => loadAndDisplayHPParts(), 0);
     // Web3 functionality
     const connectWalletBtn = document.getElementById('connectWalletBtn');
     let provider = null;

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
 
                 <section id="projects" class="section hidden">
                     <h2 class="section-title"><i class="fas fa-project-diagram"></i> Projects</h2>
-                    <div class="entry">
+                    <div class="entry" id="hp-parts-entry">
                         <h3>HP Parts List Database</h3>
                     </div>
                     <div class="entry">

--- a/ts/script.ts
+++ b/ts/script.ts
@@ -41,6 +41,7 @@ window.addEventListener('scroll', () => {
 
 // Enhanced hover effects for interactive elements
 document.addEventListener('DOMContentLoaded', () => {
+    loadAndDisplayHPParts();
     // Profile image interaction
     const profileImage = document.querySelector('.profile-image') as HTMLImageElement | null;
     if (profileImage) {
@@ -166,8 +167,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const projectsSection = document.getElementById('projects');
         if (!projectsSection) return;
 
-        const entryDiv = projectsSection.querySelector('.entry');
+        const entryDiv = projectsSection.querySelector('#hp-parts-entry');
         if (!entryDiv) return;
+
+        // Add a loading message immediately
+        entryDiv.innerHTML = '<h3>HP Parts List Database</h3><p>Loading data...</p>';
 
         try {
             const response = await fetch('data/hp_parts.json');
@@ -209,7 +213,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             table.appendChild(tbody);
 
-            // Clear existing content and append table
+            // Clear the loading message and append the table
             entryDiv.innerHTML = '<h3>HP Parts List Database</h3>';
             entryDiv.appendChild(table);
 
@@ -218,8 +222,6 @@ document.addEventListener('DOMContentLoaded', () => {
             entryDiv.innerHTML = '<h3>HP Parts List Database</h3><p>Could not load data.</p>';
         }
     }
-
-    setTimeout(() => loadAndDisplayHPParts(), 0);
 
     // Web3 functionality
     const connectWalletBtn = document.getElementById('connectWalletBtn') as HTMLButtonElement | null;


### PR DESCRIPTION
The HP parts table data is loaded asynchronously. Previously, the table would just pop in when the data arrived, which was a poor user experience.

This change improves the user experience by:
1.  Adding a unique ID to the target div for more robust selection.
2.  Displaying a "Loading data..." message immediately when the data loading process begins.
3.  Replacing the loading message with the table once the data has been successfully fetched and processed.