### PR TITLE
feat: Replace ArcGIS with OpenStreetMap

### DIFF
--- a/dist/script.js
+++ b/dist/script.js
@@ -169,31 +169,19 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
     // Web3 functionality has been removed.
-    // ArcGIS Map initialization
+    // Leaflet Map initialization
     function initializeMap() {
-        return __awaiter(this, void 0, void 0, function* () {
-            const viewDiv = document.getElementById('viewDiv');
-            if (!viewDiv || viewDiv.dataset.initialized) {
-                return;
-            }
-            // @ts-ignore
-            require([
-                "esri/config",
-                "esri/Map",
-                "esri/views/MapView"
-            ], function (esriConfig, Map, MapView) {
-                const map = new Map({
-                    basemap: "arcgis-topographic" // Basemap layer service
-                });
-                const view = new MapView({
-                    map: map,
-                    center: [-118.805, 34.027], // Longitude, latitude
-                    zoom: 13, // Zoom level
-                    container: "viewDiv" // Div element
-                });
-                viewDiv.dataset.initialized = 'true';
-            });
-        });
+        const viewDiv = document.getElementById('viewDiv');
+        if (!viewDiv || viewDiv.dataset.initialized === 'true') {
+            return;
+        }
+        // @ts-ignore
+        const L = window.L;
+        const map = L.map('viewDiv').setView([34.027, -118.805], 13);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
+        viewDiv.dataset.initialized = 'true';
     }
 });
 // Keyboard navigation accessibility

--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <meta name="description" content="Experienced IT Support Professional with 7+ years in customer service and troubleshooting. CompTIA certified with expertise in multiple programming languages.">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="css/styles.css">
-    <link rel="stylesheet" href="https://js.arcgis.com/4.29/esri/themes/light/main.css">
-    <script src="https://js.arcgis.com/4.29/"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to content</a>
@@ -143,7 +143,7 @@
                         <h3>HP Parts List Database</h3>
                     </div>
                     <div class="entry">
-                        <h3>ArcGIS Map</h3>
+                        <h3>OpenStreetMap</h3>
                         <div id="viewDiv" style="height: 400px;"></div>
                     </div>
                 </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,36 @@
       "name": "portfolio",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "leaflet": "^1.9.4"
+      },
       "devDependencies": {
+        "@types/leaflet": "^1.9.12",
         "typescript": "^5.9.2"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.20",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.20.tgz",
+      "integrity": "sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/typescript": {
       "version": "5.9.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/leaflet": "^1.9.12",
     "typescript": "^5.9.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "leaflet": "^1.9.4"
+  }
 }

--- a/ts/script.ts
+++ b/ts/script.ts
@@ -176,35 +176,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Web3 functionality has been removed.
 
-    // ArcGIS Map initialization
-    async function initializeMap() {
+    // Leaflet Map initialization
+    function initializeMap() {
         const viewDiv = document.getElementById('viewDiv');
-        if (!viewDiv || viewDiv.dataset.initialized) {
+        if (!viewDiv || viewDiv.dataset.initialized === 'true') {
             return;
         }
 
         // @ts-ignore
-        require([
-            "esri/config",
-            "esri/Map",
-            "esri/views/MapView"
-        ], function(esriConfig: any, Map: any, MapView: any) {
+        const L = window.L;
+        const map = L.map('viewDiv').setView([34.027, -118.805], 13);
 
-            const map = new Map({
-                basemap: "arcgis-topographic" // Basemap layer service
-            });
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
 
-            const view = new MapView({
-                map: map,
-                center: [-118.805, 34.027], // Longitude, latitude
-                zoom: 13, // Zoom level
-                container: "viewDiv" // Div element
-            });
-
-            viewDiv.dataset.initialized = 'true';
-        });
+        viewDiv.dataset.initialized = 'true';
     }
-
 });
 
 // Keyboard navigation accessibility


### PR DESCRIPTION
- Replaced the ArcGIS map with a Leaflet map using OpenStreetMap.
- Removed ArcGIS dependencies and added Leaflet dependencies.
- Updated the map initialization logic in the TypeScript code.
- Updated package.json to include leaflet and its types.