### PR TITLE
feat: Replace OpenStreetMap with Google Maps iframe

### DIFF
--- a/dist/script.js
+++ b/dist/script.js
@@ -117,9 +117,6 @@ document.addEventListener('DOMContentLoaded', () => {
             sections.forEach(section => {
                 if (section.id === tab) {
                     section.classList.remove('hidden');
-                    if (section.id === 'projects') {
-                        initializeMap();
-                    }
                 }
                 else {
                     section.classList.add('hidden');
@@ -169,20 +166,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
     // Web3 functionality has been removed.
-    // Leaflet Map initialization
-    function initializeMap() {
-        const viewDiv = document.getElementById('viewDiv');
-        if (!viewDiv || viewDiv.dataset.initialized === 'true') {
-            return;
-        }
-        // @ts-ignore
-        const L = window.L;
-        const map = L.map('viewDiv').setView([34.027, -118.805], 13);
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        }).addTo(map);
-        viewDiv.dataset.initialized = 'true';
-    }
 });
 // Keyboard navigation accessibility
 document.addEventListener('keydown', (e) => {

--- a/index.html
+++ b/index.html
@@ -7,8 +7,6 @@
     <meta name="description" content="Experienced IT Support Professional with 7+ years in customer service and troubleshooting. CompTIA certified with expertise in multiple programming languages.">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="css/styles.css">
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to content</a>
@@ -143,8 +141,8 @@
                         <h3>HP Parts List Database</h3>
                     </div>
                     <div class="entry">
-                        <h3>OpenStreetMap</h3>
-                        <div id="viewDiv" style="height: 400px;"></div>
+                        <h3>Map</h3>
+                        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d9217678.480645739!2d107.00376560973255!3d22.75329140749532!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x315285f132af5c3f%3A0x2ed41c6f09259f29!2sGuangdong%20Province%2C%20China!5e1!3m2!1sen!2sus!4v1759171318686!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
                     </div>
                 </section>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,36 +8,9 @@
       "name": "portfolio",
       "version": "1.0.0",
       "license": "ISC",
-      "dependencies": {
-        "leaflet": "^1.9.4"
-      },
       "devDependencies": {
-        "@types/leaflet": "^1.9.12",
         "typescript": "^5.9.2"
       }
-    },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/leaflet": {
-      "version": "1.9.20",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.20.tgz",
-      "integrity": "sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/leaflet": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/typescript": {
       "version": "5.9.2",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/leaflet": "^1.9.12",
     "typescript": "^5.9.2"
   },
-  "dependencies": {
-    "leaflet": "^1.9.4"
-  }
+  "dependencies": {}
 }

--- a/ts/script.ts
+++ b/ts/script.ts
@@ -118,9 +118,6 @@ document.addEventListener('DOMContentLoaded', () => {
             sections.forEach(section => {
                 if (section.id === tab) {
                     section.classList.remove('hidden');
-                    if (section.id === 'projects') {
-                        initializeMap();
-                    }
                 } else {
                     section.classList.add('hidden');
                 }
@@ -175,24 +172,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Web3 functionality has been removed.
-
-    // Leaflet Map initialization
-    function initializeMap() {
-        const viewDiv = document.getElementById('viewDiv');
-        if (!viewDiv || viewDiv.dataset.initialized === 'true') {
-            return;
-        }
-
-        // @ts-ignore
-        const L = window.L;
-        const map = L.map('viewDiv').setView([34.027, -118.805], 13);
-
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        }).addTo(map);
-
-        viewDiv.dataset.initialized = 'true';
-    }
 });
 
 // Keyboard navigation accessibility


### PR DESCRIPTION
This commit removes the OpenStreetMap (Leaflet) implementation and replaces it with an embedded Google Maps iframe as requested.

Key changes:
- Removed Leaflet CSS and JS from `index.html`.
- Removed the Leaflet map container from `index.html`.
- Removed the map initialization code from `ts/script.ts`.
- Removed `leaflet` and `@types/leaflet` from `package.json`.
- Added the provided Google Maps iframe to the 'Projects' section.