### PR TITLE
feat: Add supply chain analysis table and replace map

### DIFF
--- a/data/supply_chain.json
+++ b/data/supply_chain.json
@@ -1,0 +1,100 @@
+[
+  {
+    "Model Series": "Elitebook",
+    "Generation": "G5",
+    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics",
+    "Notes & Context": "At the time of the G5's production, Chongqing was solidifying its status as the world's largest laptop manufacturing base."
+  },
+  {
+    "Model Series": "Zbook Studio",
+    "Generation": "G5",
+    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics",
+    "Notes & Context": "At the time of the G5's production, Chongqing was solidifying its status as the world's largest laptop manufacturing base."
+  },
+  {
+    "Model Series": "Elitebook",
+    "Generation": "G6",
+    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Wistron",
+    "Notes & Context": "Supply chains were heavily concentrated in mainland China. The G6 followed this established manufacturing footprint."
+  },
+  {
+    "Model Series": "Zbook Studio",
+    "Generation": "G6",
+    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Wistron",
+    "Notes & Context": "Supply chains were heavily concentrated in mainland China. The G6 followed this established manufacturing footprint."
+  },
+  {
+    "Model Series": "Elitebook",
+    "Generation": "G7",
+    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Wistron",
+    "Notes & Context": "Production continued in established Chinese industrial hubs. Minor disruptions began to appear due to early pandemic-related supply chain issues."
+  },
+  {
+    "Model Series": "Zbook Studio",
+    "Generation": "G7",
+    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Wistron",
+    "Notes & Context": "Production continued in established Chinese industrial hubs. Minor disruptions began to appear due to early pandemic-related supply chain issues."
+  },
+  {
+    "Model Series": "Elitebook",
+    "Generation": "G8",
+    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics",
+    "Notes & Context": "The pandemic solidified the reliance on these large-scale manufacturing centers, even as global logistics became more complex."
+  },
+  {
+    "Model Series": "Zbook Studio",
+    "Generation": "G8",
+    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics",
+    "Notes & Context": "The pandemic solidified the reliance on these large-scale manufacturing centers, even as global logistics became more complex."
+  },
+  {
+    "Model Series": "Elitebook",
+    "Generation": "G9",
+    "Typical Final Assembly Location(s)": "China, Vietnam",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Notes & Context": "HP began to diversify its assembly locations more significantly. While still primarily in China, some production shifted to Vietnam as part of a 'China +1' strategy."
+  },
+  {
+    "Model Series": "Zbook Studio",
+    "Generation": "G9",
+    "Typical Final Assembly Location(s)": "China, Vietnam",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Notes & Context": "HP began to diversify its assembly locations more significantly. While still primarily in China, some production shifted to Vietnam as part of a 'China +1' strategy."
+  },
+  {
+    "Model Series": "Elitebook",
+    "Generation": "G10",
+    "Typical Final Assembly Location(s)": "China, Vietnam, Mexico",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Notes & Context": "Diversification continues. Assembly in Mexico often serves the North American market more directly, reducing shipping times and tariffs."
+  },
+  {
+    "Model Series": "Zbook Studio",
+    "Generation": "G10",
+    "Typical Final Assembly Location(s)": "China, Vietnam, Mexico",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Notes & Context": "Diversification continues. Assembly in Mexico often serves the North American market more directly, reducing shipping times and tariffs."
+  },
+  {
+    "Model Series": "Elitebook",
+    "Generation": "G11",
+    "Typical Final Assembly Location(s)": "China, Vietnam, Mexico, USA (Limited)",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Notes & Context": "The trend of geographic diversification is most pronounced with the latest models. Limited final assembly or 'fulfillment' for specific large corporate or government orders may occur in the USA."
+  },
+  {
+    "Model Series": "Zbook Studio",
+    "Generation": "G11",
+    "Typical Final Assembly Location(s)": "China, Vietnam, Mexico, USA (Limited)",
+    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Notes & Context": "The trend of geographic diversification is most pronounced with the latest models. Limited final assembly or 'fulfillment' for specific large corporate or government orders may occur in the USA."
+  }
+]

--- a/index.html
+++ b/index.html
@@ -140,6 +140,9 @@
                     <div class="entry" id="hp-parts-entry">
                         <h3>HP Parts List Database</h3>
                     </div>
+                    <div class="entry" id="supply-chain-entry">
+                        <h3>Supply Chain Analysis</h3>
+                    </div>
                     <div class="entry">
                         <h3>Map</h3>
                         <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d9217678.480645739!2d107.00376560973255!3d22.75329140749532!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x315285f132af5c3f%3A0x2ed41c6f09259f29!2sGuangdong%20Province%2C%20China!5e1!3m2!1sen!2sus!4v1759171318686!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>

--- a/ts/script.ts
+++ b/ts/script.ts
@@ -81,7 +81,70 @@ document.addEventListener('DOMContentLoaded', () => {
             entryDiv.innerHTML = '<h3>HP Parts List Database</h3><p>Could not load data.</p>';
         }
     }
-    loadAndDisplayHPParts(); // Commented out for diagnostic purposes
+    loadAndDisplayHPParts();
+
+    // Supply Chain Analysis functionality
+    async function loadAndDisplaySupplyChainData() {
+        const projectsSection = document.getElementById('projects');
+        if (!projectsSection) return;
+
+        const entryDiv = projectsSection.querySelector('#supply-chain-entry');
+        if (!entryDiv) return;
+
+        // Add a loading message immediately
+        entryDiv.innerHTML = '<h3>Supply Chain Analysis</h3><p>Loading data...</p>';
+
+        try {
+            const response = await fetch('data/supply_chain.json');
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const data = await response.json();
+
+            if (!Array.isArray(data) || data.length === 0) {
+                entryDiv.innerHTML = '<h3>Supply Chain Analysis</h3><p>No data available.</p>';
+                return;
+            }
+
+            const table = document.createElement('table');
+            table.classList.add('supply-chain-table');
+
+            // Create table header
+            const thead = document.createElement('thead');
+            const headerRow = document.createElement('tr');
+            const headers = Object.keys(data[0]);
+            headers.forEach(headerText => {
+                const th = document.createElement('th');
+                th.textContent = headerText;
+                headerRow.appendChild(th);
+            });
+            thead.appendChild(headerRow);
+            table.appendChild(thead);
+
+            // Create table body
+            const tbody = document.createElement('tbody');
+            data.forEach(item => {
+                const row = document.createElement('tr');
+                headers.forEach(header => {
+                    const cell = document.createElement('td');
+                    cell.textContent = item[header];
+                    row.appendChild(cell);
+                });
+                tbody.appendChild(row);
+            });
+            table.appendChild(tbody);
+
+            // Clear the loading message and append the table
+            entryDiv.innerHTML = '<h3>Supply Chain Analysis</h3>';
+            entryDiv.appendChild(table);
+
+        } catch (error) {
+            console.error('Error fetching or displaying supply chain data:', error);
+            entryDiv.innerHTML = '<h3>Supply Chain Analysis</h3><p>Could not load data.</p>';
+        }
+    }
+    loadAndDisplaySupplyChainData();
+
     // Profile image interaction
     const profileImage = document.querySelector('.profile-image') as HTMLImageElement | null;
     if (profileImage) {


### PR DESCRIPTION
This commit introduces a new "Supply Chain Analysis" table to the projects section and replaces the previous OpenStreetMap implementation with a Google Maps iframe.

Key changes:
- Restored the original `hp_parts.json` to preserve existing data.
- Created a new `data/supply_chain.json` with the user-provided manufacturing data.
- Added a new section to `index.html` to display the supply chain table.
- Added a new function in `ts/script.ts` to fetch and render the supply chain data.
- Replaced the OpenStreetMap implementation with a Google Maps iframe.
- Removed all remnants of the Leaflet library and its dependencies.