### PR TITLE
Feat: Add copy-to-clipboard buttons for part numbers

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -333,6 +333,7 @@ table.table tbody tr:hover {
 
 .laptop-card .spec {
     display: flex;
+    align-items: center;
     margin-bottom: 0.75rem;
     font-size: 0.9rem;
 }
@@ -347,4 +348,28 @@ table.table tbody tr:hover {
 .laptop-card .spec-value {
     color: #f0f0f0;
     flex-grow: 1;
+    margin-right: 0.5rem;
+}
+
+.copy-button {
+    background-color: #007acc;
+    border: none;
+    color: white;
+    padding: 0.3rem 0.6rem;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    flex-shrink: 0;
+}
+
+.copy-button:hover {
+    background-color: #005fa3;
+}
+
+.copy-button i {
+    font-size: 0.8rem;
+}
+
+.copy-button .fa-check {
+    color: #42f598;
 }

--- a/js/laptops.jsx
+++ b/js/laptops.jsx
@@ -1,3 +1,22 @@
+const CopyToClipboard = ({ text }) => {
+    const [isCopied, setIsCopied] = React.useState(false);
+
+    const copy = () => {
+        navigator.clipboard.writeText(text).then(() => {
+            setIsCopied(true);
+            setTimeout(() => {
+                setIsCopied(false);
+            }, 2000); // Reset after 2 seconds
+        });
+    };
+
+    return (
+        <button onClick={copy} className="copy-button" title="Copy to clipboard">
+            {isCopied ? <i className="fas fa-check"></i> : <i className="fas fa-copy"></i>}
+        </button>
+    );
+};
+
 const LaptopCard = ({ laptop }) => {
     const specsToShow = {
         "Processor": laptop.Processor,
@@ -5,11 +24,13 @@ const LaptopCard = ({ laptop }) => {
         "Internal Drive": laptop["Internal Drive"],
         "Display": laptop.Display,
         "Graphics": laptop.Graphics,
-        "Screen Part #": laptop["Screen Replacement Part # (Common)"],
-        "Battery Part #": laptop["Battery Replacement Part # (Common)"],
-        "RAM Part #": laptop["RAM Replacement Part # (Common)"],
-        "SSD Part #": laptop["SSD Replacement Part # (Common)"]
+        "Screen Part #(s)": laptop["Screen Replacement Part # (Common)"],
+        "Battery Part #(s)": laptop["Battery Replacement Part # (Common)"],
+        "RAM Part #(s)": laptop["RAM Replacement Part # (Common)"],
+        "SSD Part #(s)": laptop["SSD Replacement Part # (Common)"]
     };
+
+    const partNumberKeys = ["Screen Part #(s)", "Battery Part #(s)", "RAM Part #(s)", "SSD Part #(s)"];
 
     return (
         <div className="laptop-card">
@@ -20,6 +41,7 @@ const LaptopCard = ({ laptop }) => {
                         <div key={key} className="spec">
                             <span className="spec-key">{key}:</span>
                             <span className="spec-value">{value}</span>
+                            {partNumberKeys.includes(key) && <CopyToClipboard text={value} />}
                         </div>
                     );
                 }


### PR DESCRIPTION
This commit introduces a new feature that adds a copy-to-clipboard button next to the part number fields on the laptops page.

- A new `CopyToClipboard` React component was created to handle the copy functionality and provide visual feedback to the user.
- The `LaptopCard` component was updated to include the `CopyToClipboard` button for the 'Screen Part #(s)', 'Battery Part #(s)', 'RAM Part #(s)', and 'SSD Part #(s)' fields.
- CSS styles were added to ensure the new buttons are visually appealing and consistent with the existing design.