### PR TITLE
feat: Add Google Maps to Supply Chain page

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -82,10 +82,36 @@ function createSupplyChainCard(container, item) {
 
             const valueSpan = document.createElement('span');
             valueSpan.className = 'spec-value';
-            valueSpan.textContent = value;
-            specDiv.appendChild(valueSpan);
 
+            if (key === "Assembly Partners (ODMs)" && Array.isArray(value)) {
+                valueSpan.textContent = value.map(partner => partner.name).join(', ');
+            } else {
+                valueSpan.textContent = value;
+            }
+
+            specDiv.appendChild(valueSpan);
             card.appendChild(specDiv);
+
+            if (key === "Assembly Partners (ODMs)" && Array.isArray(value)) {
+                value.forEach(partner => {
+                    if (partner.map_url) {
+                        const mapContainer = document.createElement('div');
+                        mapContainer.className = 'map-container';
+
+                        const iframe = document.createElement('iframe');
+                        iframe.src = partner.map_url;
+                        iframe.width = '100%';
+                        iframe.height = '250';
+                        iframe.style.border = 0;
+                        iframe.allowFullscreen = true;
+                        iframe.loading = 'lazy';
+                        iframe.title = `Map of ${partner.name} headquarters`;
+
+                        mapContainer.appendChild(iframe);
+                        card.appendChild(mapContainer);
+                    }
+                });
+            }
         }
     }
     container.appendChild(card);

--- a/supply_chain.json
+++ b/supply_chain.json
@@ -3,98 +3,150 @@
     "Model Series": "Elitebook",
     "Generation": "G5",
     "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "At the time of the G5's production, Chongqing was solidifying its status as the world's largest laptop manufacturing base."
   },
   {
     "Model Series": "Zbook Studio",
     "Generation": "G5",
     "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "At the time of the G5's production, Chongqing was solidifying its status as the world's largest laptop manufacturing base."
   },
   {
     "Model Series": "Elitebook",
     "Generation": "G6",
     "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Wistron",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "Supply chains were heavily concentrated in mainland China. The G6 followed this established manufacturing footprint."
   },
   {
     "Model Series": "Zbook Studio",
     "Generation": "G6",
     "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Wistron",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "Supply chains were heavily concentrated in mainland China. The G6 followed this established manufacturing footprint."
   },
   {
     "Model Series": "Elitebook",
     "Generation": "G7",
     "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Wistron",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "Production continued in established Chinese industrial hubs. Minor disruptions began to appear due to early pandemic-related supply chain issues."
   },
   {
     "Model Series": "Zbook Studio",
     "Generation": "G7",
     "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Wistron",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "Production continued in established Chinese industrial hubs. Minor disruptions began to appear due to early pandemic-related supply chain issues."
   },
   {
     "Model Series": "Elitebook",
     "Generation": "G8",
     "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "The pandemic solidified the reliance on these large-scale manufacturing centers, even as global logistics became more complex."
   },
   {
     "Model Series": "Zbook Studio",
     "Generation": "G8",
     "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "The pandemic solidified the reliance on these large-scale manufacturing centers, even as global logistics became more complex."
   },
   {
     "Model Series": "Elitebook",
     "Generation": "G9",
     "Typical Final Assembly Location(s)": "China, Vietnam",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "HP began to diversify its assembly locations more significantly. While still primarily in China, some production shifted to Vietnam as part of a 'China +1' strategy."
   },
   {
     "Model Series": "Zbook Studio",
     "Generation": "G9",
     "Typical Final Assembly Location(s)": "China, Vietnam",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "HP began to diversify its assembly locations more significantly. While still primarily in China, some production shifted to Vietnam as part of a 'China +1' strategy."
   },
   {
     "Model Series": "Elitebook",
     "Generation": "G10",
     "Typical Final Assembly Location(s)": "China, Vietnam, Mexico",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "Diversification continues. Assembly in Mexico often serves the North American market more directly, reducing shipping times and tariffs."
   },
   {
     "Model Series": "Zbook Studio",
     "Generation": "G10",
     "Typical Final Assembly Location(s)": "China, Vietnam, Mexico",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "Diversification continues. Assembly in Mexico often serves the North American market more directly, reducing shipping times and tariffs."
   },
   {
     "Model Series": "Elitebook",
     "Generation": "G11",
     "Typical Final Assembly Location(s)": "China, Vietnam, Mexico, USA (Limited)",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "The trend of geographic diversification is most pronounced with the latest models. Limited final assembly or 'fulfillment' for specific large corporate or government orders may occur in the USA."
   },
   {
     "Model Series": "Zbook Studio",
     "Generation": "G11",
     "Typical Final Assembly Location(s)": "China, Vietnam, Mexico, USA (Limited)",
-    "Primary Assembly Partners (ODMs)": "Quanta Computer, Compal Electronics, Foxconn",
+    "Primary Assembly Partners (ODMs)": [
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Notes & Context": "The trend of geographic diversification is most pronounced with the latest models. Limited final assembly or 'fulfillment' for specific large corporate or government orders may occur in the USA."
   }
 ]


### PR DESCRIPTION
This commit introduces Google Maps iFrames to the "Supply Chain Analysis" section of the website.

The `supply_chain.json` data has been updated to include map URLs for each assembly partner. The `js/main.js` script has been modified to dynamically generate and embed these maps into the corresponding laptop cards. This provides a visual representation of the partners' locations, enhancing the supply chain analysis.