### PR TITLE
feat: Add Google Maps to Supply Chain page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -421,4 +421,14 @@ table.table tbody tr:hover {
     margin-top: 1rem;
     border-radius: 8px;
     overflow: hidden;
+    border: 1px solid #4a4a4a;
+    padding: 1rem;
+    background-color: #343a40;
+}
+
+.map-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #e0e0e0;
+    margin-bottom: 0.75rem;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -80,8 +80,8 @@ function createSupplyChainCard(container, item) {
     title.textContent = `${item["Model Series"]} ${item["Generation"]}`;
     card.appendChild(title);
 
-    // Infographic for Assembly Location(s)
-    if (item["Typical Final Assembly Location(s)"]) {
+    // Maps for Assembly Location(s)
+    if (Array.isArray(item["Typical Final Assembly Location(s)"]) && item["Typical Final Assembly Location(s)"].length > 0) {
         const specDiv = document.createElement('div');
         specDiv.className = 'spec';
 
@@ -89,57 +89,31 @@ function createSupplyChainCard(container, item) {
         keySpan.className = 'spec-key';
         keySpan.textContent = 'Assembly Location(s):';
         specDiv.appendChild(keySpan);
-
-        const chartContainer = document.createElement('div');
-        chartContainer.className = 'infographic-container infographic-container-bar';
-        const canvas = document.createElement('canvas');
-        // Generate a unique ID for the canvas
-        const canvasId = `locations-chart-${item["Model Series"]}-${item["Generation"]}`.replace(/\s+/g, '-');
-        canvas.id = canvasId;
-        chartContainer.appendChild(canvas);
-        specDiv.appendChild(chartContainer);
         card.appendChild(specDiv);
 
-        // Defer chart creation until the card is in the DOM
-        setTimeout(() => {
-            const ctx = document.getElementById(canvasId).getContext('2d');
-            const locations = item["Typical Final Assembly Location(s)"].split(',').map(s => s.trim());
-            new Chart(ctx, {
-                type: 'bar',
-                data: {
-                    labels: locations,
-                    datasets: [{
-                        label: 'Assembly Presence',
-                        data: locations.map(() => 1), // Equal representation
-                        backgroundColor: 'rgba(54, 162, 235, 0.6)',
-                        borderColor: 'rgba(54, 162, 235, 1)',
-                        borderWidth: 1
-                    }]
-                },
-                options: {
-                    indexAxis: 'y',
-                    scales: {
-                        x: {
-                            display: false,
-                            beginAtZero: true,
-                            max: 1.1
-                        },
-                        y: {
-                             ticks: {
-                                font: {
-                                    size: 12
-                                }
-                            }
-                        }
-                    },
-                    plugins: {
-                        legend: {
-                            display: false
-                        }
-                    }
-                }
-            });
-        }, 0);
+        item["Typical Final Assembly Location(s)"].forEach(location => {
+            if (location.map_url) {
+                const mapContainer = document.createElement('div');
+                mapContainer.className = 'map-container';
+
+                const locationTitle = document.createElement('h4');
+                locationTitle.className = 'map-title';
+                locationTitle.textContent = location.name;
+                mapContainer.appendChild(locationTitle);
+
+                const iframe = document.createElement('iframe');
+                iframe.src = location.map_url;
+                iframe.width = '100%';
+                iframe.height = '250';
+                iframe.style.border = 0;
+                iframe.allowFullscreen = true;
+                iframe.loading = 'lazy';
+                iframe.title = `Map of ${location.name}`;
+
+                mapContainer.appendChild(iframe);
+                card.appendChild(mapContainer);
+            }
+        });
     }
 
     // Infographic for Assembly Partners (ODMs)

--- a/supply_chain.json
+++ b/supply_chain.json
@@ -2,7 +2,10 @@
   {
     "Model Series": "Elitebook",
     "Generation": "G5",
-    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Typical Final Assembly Location(s)": [
+        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
@@ -12,7 +15,10 @@
   {
     "Model Series": "Zbook Studio",
     "Generation": "G5",
-    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Typical Final Assembly Location(s)": [
+        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
@@ -22,7 +28,10 @@
   {
     "Model Series": "Elitebook",
     "Generation": "G6",
-    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Typical Final Assembly Location(s)": [
+        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
@@ -33,7 +42,10 @@
   {
     "Model Series": "Zbook Studio",
     "Generation": "G6",
-    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Typical Final Assembly Location(s)": [
+        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
@@ -44,7 +56,10 @@
   {
     "Model Series": "Elitebook",
     "Generation": "G7",
-    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Typical Final Assembly Location(s)": [
+        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
@@ -55,7 +70,10 @@
   {
     "Model Series": "Zbook Studio",
     "Generation": "G7",
-    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Typical Final Assembly Location(s)": [
+        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
@@ -66,7 +84,10 @@
   {
     "Model Series": "Elitebook",
     "Generation": "G8",
-    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Typical Final Assembly Location(s)": [
+        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
@@ -76,7 +97,10 @@
   {
     "Model Series": "Zbook Studio",
     "Generation": "G8",
-    "Typical Final Assembly Location(s)": "China (Primarily Chongqing, Kunshan)",
+    "Typical Final Assembly Location(s)": [
+        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
@@ -86,7 +110,10 @@
   {
     "Model Series": "Elitebook",
     "Generation": "G9",
-    "Typical Final Assembly Location(s)": "China, Vietnam",
+    "Typical Final Assembly Location(s)": [
+        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
@@ -97,7 +124,10 @@
   {
     "Model Series": "Zbook Studio",
     "Generation": "G9",
-    "Typical Final Assembly Location(s)": "China, Vietnam",
+    "Typical Final Assembly Location(s)": [
+        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
@@ -108,7 +138,11 @@
   {
     "Model Series": "Elitebook",
     "Generation": "G10",
-    "Typical Final Assembly Location(s)": "China, Vietnam, Mexico",
+    "Typical Final Assembly Location(s)": [
+        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Mexico", "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
@@ -119,7 +153,11 @@
   {
     "Model Series": "Zbook Studio",
     "Generation": "G10",
-    "Typical Final Assembly Location(s)": "China, Vietnam, Mexico",
+    "Typical Final Assembly Location(s)": [
+        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Mexico", "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
@@ -130,7 +168,12 @@
   {
     "Model Series": "Elitebook",
     "Generation": "G11",
-    "Typical Final Assembly Location(s)": "China, Vietnam, Mexico, USA (Limited)",
+    "Typical Final Assembly Location(s)": [
+        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Mexico", "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"},
+        {"name": "USA (Limited)", "map_url": "https://maps.google.com/maps?q=USA&t=&z=4&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
@@ -141,7 +184,12 @@
   {
     "Model Series": "Zbook Studio",
     "Generation": "G11",
-    "Typical Final Assembly Location(s)": "China, Vietnam, Mexico, USA (Limited)",
+    "Typical Final Assembly Location(s)": [
+        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"},
+        {"name": "Mexico", "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"},
+        {"name": "USA (Limited)", "map_url": "https://maps.google.com/maps?q=USA&t=&z=4&ie=UTF8&iwloc=&output=embed"}
+    ],
     "Primary Assembly Partners (ODMs)": [
         {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
         {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},


### PR DESCRIPTION
Replaces the bar chart for "Assembly Location(s)" with embedded Google Maps iFrames.

- Updates `supply_chain.json` to store assembly locations as an array of objects, each with a name and a `map_url`.
- Modifies `js/main.js` to parse the new data structure and dynamically create and display an embedded Google Map for each location.
- Adds CSS styles for the map containers and titles to ensure they are visually integrated with the page design.