### PR TITLE
feat: Replace partner pie chart with logos

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -432,3 +432,31 @@ table.table tbody tr:hover {
     color: #e0e0e0;
     margin-bottom: 0.75rem;
 }
+
+/* --- Partner Logo Styles --- */
+.spec-partners {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.logo-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    align-items: center;
+    margin-top: 1rem;
+    width: 100%;
+}
+
+.partner-logo {
+    max-height: 40px;
+    max-width: 120px;
+    filter: brightness(0) invert(0.9); /* Make logos white to match theme */
+    opacity: 0.8;
+    transition: opacity 0.3s ease;
+}
+
+.partner-logo:hover {
+    opacity: 1;
+    filter: brightness(0) invert(1); /* Make logos pure white on hover */
+}

--- a/js/main.js
+++ b/js/main.js
@@ -116,64 +116,38 @@ function createSupplyChainCard(container, item) {
         });
     }
 
-    // Infographic for Assembly Partners (ODMs)
-    if (item["Primary Assembly Partners (ODMs)"] && item["Primary Assembly Partners (ODMs)"].length > 0) {
+    // Logos for Assembly Partners (ODMs)
+    if (Array.isArray(item["Primary Assembly Partners (ODMs)"]) && item["Primary Assembly Partners (ODMs)"].length > 0) {
         const specDiv = document.createElement('div');
-        specDiv.className = 'spec';
+        specDiv.className = 'spec spec-partners';
 
         const keySpan = document.createElement('span');
         keySpan.className = 'spec-key';
         keySpan.textContent = 'Assembly Partners (ODMs):';
         specDiv.appendChild(keySpan);
 
-        const chartContainer = document.createElement('div');
-        chartContainer.className = 'infographic-container infographic-container-pie';
-        const canvas = document.createElement('canvas');
-        const canvasId = `partners-chart-${item["Model Series"]}-${item["Generation"]}`.replace(/\s+/g, '-');
-        canvas.id = canvasId;
-        chartContainer.appendChild(canvas);
-        specDiv.appendChild(chartContainer);
-        card.appendChild(specDiv);
+        const logoContainer = document.createElement('div');
+        logoContainer.className = 'logo-container';
 
-        setTimeout(() => {
-            const ctx = document.getElementById(canvasId).getContext('2d');
-            const partners = item["Primary Assembly Partners (ODMs)"].map(p => p.name);
-            new Chart(ctx, {
-                type: 'pie',
-                data: {
-                    labels: partners,
-                    datasets: [{
-                        data: partners.map(() => 1), // Equal slices
-                        backgroundColor: [
-                            'rgba(255, 99, 132, 0.6)',
-                            'rgba(54, 162, 235, 0.6)',
-                            'rgba(255, 206, 86, 0.6)',
-                            'rgba(75, 192, 192, 0.6)',
-                        ],
-                        borderColor: [
-                            'rgba(255, 99, 132, 1)',
-                            'rgba(54, 162, 235, 1)',
-                            'rgba(255, 206, 86, 1)',
-                            'rgba(75, 192, 192, 1)',
-                        ],
-                        borderWidth: 1
-                    }]
-                },
-                options: {
-                    responsive: true,
-                    plugins: {
-                        legend: {
-                            position: 'top',
-                             labels: {
-                                font: {
-                                    size: 12
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-        }, 0);
+        item["Primary Assembly Partners (ODMs)"].forEach(partner => {
+            if (partner.logo_url) {
+                const logoLink = document.createElement('a');
+                logoLink.href = partner.map_url;
+                logoLink.target = '_blank';
+                logoLink.title = `View map of ${partner.name}`;
+
+                const logoImg = document.createElement('img');
+                logoImg.src = partner.logo_url;
+                logoImg.alt = `${partner.name} logo`;
+                logoImg.className = 'partner-logo';
+
+                logoLink.appendChild(logoImg);
+                logoContainer.appendChild(logoLink);
+            }
+        });
+
+        specDiv.appendChild(logoContainer);
+        card.appendChild(specDiv);
     }
 
     // Infographic for Notes & Context

--- a/supply_chain.json
+++ b/supply_chain.json
@@ -7,8 +7,8 @@
         {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"}
     ],
     "Notes & Context": "At the time of the G5's production, Chongqing was solidifying its status as the world's largest laptop manufacturing base."
   },
@@ -20,8 +20,8 @@
         {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"}
     ],
     "Notes & Context": "At the time of the G5's production, Chongqing was solidifying its status as the world's largest laptop manufacturing base."
   },
@@ -33,9 +33,9 @@
         {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
+        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"}
     ],
     "Notes & Context": "Supply chains were heavily concentrated in mainland China. The G6 followed this established manufacturing footprint."
   },
@@ -47,9 +47,9 @@
         {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
+        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"}
     ],
     "Notes & Context": "Supply chains were heavily concentrated in mainland China. The G6 followed this established manufacturing footprint."
   },
@@ -61,9 +61,9 @@
         {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
+        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"}
     ],
     "Notes & Context": "Production continued in established Chinese industrial hubs. Minor disruptions began to appear due to early pandemic-related supply chain issues."
   },
@@ -75,9 +75,9 @@
         {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
+        {"name": "Wistron", "map_url": "https://maps.google.com/maps?q=Wistron+Corporation,+No.+158,+Xingshan+Road,+Neihu+District,+Taipei,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"}
     ],
     "Notes & Context": "Production continued in established Chinese industrial hubs. Minor disruptions began to appear due to early pandemic-related supply chain issues."
   },
@@ -89,8 +89,8 @@
         {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"}
     ],
     "Notes & Context": "The pandemic solidified the reliance on these large-scale manufacturing centers, even as global logistics became more complex."
   },
@@ -102,8 +102,8 @@
         {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"}
     ],
     "Notes & Context": "The pandemic solidified the reliance on these large-scale manufacturing centers, even as global logistics became more complex."
   },
@@ -115,9 +115,9 @@
         {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
     ],
     "Notes & Context": "HP began to diversify its assembly locations more significantly. While still primarily in China, some production shifted to Vietnam as part of a 'China +1' strategy."
   },
@@ -129,9 +129,9 @@
         {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
     ],
     "Notes & Context": "HP began to diversify its assembly locations more significantly. While still primarily in China, some production shifted to Vietnam as part of a 'China +1' strategy."
   },
@@ -144,9 +144,9 @@
         {"name": "Mexico", "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
     ],
     "Notes & Context": "Diversification continues. Assembly in Mexico often serves the North American market more directly, reducing shipping times and tariffs."
   },
@@ -159,9 +159,9 @@
         {"name": "Mexico", "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
     ],
     "Notes & Context": "Diversification continues. Assembly in Mexico often serves the North American market more directly, reducing shipping times and tariffs."
   },
@@ -175,9 +175,9 @@
         {"name": "USA (Limited)", "map_url": "https://maps.google.com/maps?q=USA&t=&z=4&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
     ],
     "Notes & Context": "The trend of geographic diversification is most pronounced with the latest models. Limited final assembly or 'fulfillment' for specific large corporate or government orders may occur in the USA."
   },
@@ -191,9 +191,9 @@
         {"name": "USA (Limited)", "map_url": "https://maps.google.com/maps?q=USA&t=&z=4&ie=UTF8&iwloc=&output=embed"}
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed"}
+        {"name": "Quanta Computer", "map_url": "https://maps.google.com/maps?q=Quanta+Computer+Inc.,+No.+211,+Wenhua+2nd+Rd.,+Guishan+Dist.,+Taoyuan+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
+        {"name": "Compal Electronics", "map_url": "https://maps.google.com/maps?q=Compal+Electronics,+No.+581,+Ruiguang+Rd.,+Neihu+District,+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
+        {"name": "Foxconn", "map_url": "https://maps.google.com/maps?q=Foxconn,+No.+66-1,+Zhongshan+Road,+Tucheng+District,+New+Taipei+City,+Taiwan&t=&z=13&ie=UTF8&iwloc=&output=embed", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
     ],
     "Notes & Context": "The trend of geographic diversification is most pronounced with the latest models. Limited final assembly or 'fulfillment' for specific large corporate or government orders may occur in the USA."
   }


### PR DESCRIPTION
Replaces the pie chart for "Assembly Partners (ODMs)" with company logos.

- Updates `supply_chain.json` to include a `logo_url` for each assembly partner.
- Modifies `js/main.js` to remove the pie chart and instead render the company logos.
- Adds CSS styles to ensure the logos are displayed correctly within the cards.