### PR TITLE
refactor: Replace partner logos with text links

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -375,29 +375,12 @@ table.table tbody tr:hover {
 }
 
 /* --- Infographic and Supply Chain Styles --- */
-.infographic-container {
-    padding-top: 1rem;
-    width: 100%;
-    margin-bottom: 1rem;
-    position: relative;
-}
-
-.infographic-container-bar {
-    min-height: 120px;
-}
-
-.infographic-container-pie {
-    min-height: 220px;
-}
-
 /* Restyle spec blocks that contain our new infographics */
-.spec:has(.infographic-container),
 .spec:has(.spec-value-context) {
     flex-direction: column;
     align-items: flex-start;
 }
 
-.spec:has(.infographic-container) .spec-key,
 .spec:has(.spec-value-context) .spec-key {
     width: 100%;
     margin-bottom: 0.5rem;
@@ -431,32 +414,4 @@ table.table tbody tr:hover {
     font-weight: 600;
     color: #e0e0e0;
     margin-bottom: 0.75rem;
-}
-
-/* --- Partner Logo Styles --- */
-.spec-partners {
-    flex-direction: column;
-    align-items: flex-start;
-}
-
-.logo-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-    align-items: center;
-    margin-top: 1rem;
-    width: 100%;
-}
-
-.partner-logo {
-    max-height: 40px;
-    max-width: 120px;
-    filter: brightness(0) invert(0.9); /* Make logos white to match theme */
-    opacity: 0.8;
-    transition: opacity 0.3s ease;
-}
-
-.partner-logo:hover {
-    opacity: 1;
-    filter: brightness(0) invert(1); /* Make logos pure white on hover */
 }

--- a/js/main.js
+++ b/js/main.js
@@ -116,37 +116,37 @@ function createSupplyChainCard(container, item) {
         });
     }
 
-    // Logos for Assembly Partners (ODMs)
+    // Text links for Assembly Partners (ODMs)
     if (Array.isArray(item["Primary Assembly Partners (ODMs)"]) && item["Primary Assembly Partners (ODMs)"].length > 0) {
         const specDiv = document.createElement('div');
-        specDiv.className = 'spec spec-partners';
+        specDiv.className = 'spec';
 
         const keySpan = document.createElement('span');
         keySpan.className = 'spec-key';
         keySpan.textContent = 'Assembly Partners (ODMs):';
         specDiv.appendChild(keySpan);
 
-        const logoContainer = document.createElement('div');
-        logoContainer.className = 'logo-container';
+        const valueSpan = document.createElement('span');
+        valueSpan.className = 'spec-value';
 
-        item["Primary Assembly Partners (ODMs)"].forEach(partner => {
-            if (partner.logo_url) {
-                const logoLink = document.createElement('a');
-                logoLink.href = partner.map_url;
-                logoLink.target = '_blank';
-                logoLink.title = `Visit website of ${partner.name}`;
+        item["Primary Assembly Partners (ODMs)"].forEach((partner, index) => {
+            if (partner.map_url && partner.name) {
+                const partnerLink = document.createElement('a');
+                partnerLink.href = partner.map_url;
+                partnerLink.target = '_blank';
+                partnerLink.textContent = partner.name;
 
-                const logoImg = document.createElement('img');
-                logoImg.src = partner.logo_url;
-                logoImg.alt = `${partner.name} logo`;
-                logoImg.className = 'partner-logo';
+                valueSpan.appendChild(partnerLink);
 
-                logoLink.appendChild(logoImg);
-                logoContainer.appendChild(logoLink);
+                // Add a separator if it's not the last item
+                if (index < item["Primary Assembly Partners (ODMs)"].length - 1) {
+                    const separator = document.createTextNode(', ');
+                    valueSpan.appendChild(separator);
+                }
             }
         });
 
-        specDiv.appendChild(logoContainer);
+        specDiv.appendChild(valueSpan);
         card.appendChild(specDiv);
     }
 

--- a/pages/supply_chain.html
+++ b/pages/supply_chain.html
@@ -12,7 +12,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
 
     <link rel="stylesheet" href="../css/styles.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Replaces the assembly partner logos with simple text-based links to their official websites.

- Modifies `js/main.js` to generate `<a>` tags with the partner's name as the text content instead of `<img>` tags.
- Removes the now-unused CSS styles for the partner logos from `css/styles.css`.
- Removes the unused Chart.js script from `pages/supply_chain.html` as it is no longer needed.