### PR TITLE
fix: supply chain map iframe connection refused errors

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -871,6 +871,7 @@ footer {
     border: 1px solid #4a4a4a;
     padding: 1rem;
     background-color: #343a40;
+}
 
 .category-title {
     font-size: 1.2rem;

--- a/data/supply_chain.json
+++ b/data/supply_chain.json
@@ -3,12 +3,26 @@
     "Model Series": "Elitebook",
     "Generation": "G5",
     "Typical Final Assembly Location(s)": [
-        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "Chongqing, China",
+        "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Kunshan, China",
+        "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      }
     ],
     "Notes & Context": "At the time of the G5's production, Chongqing was solidifying its status as the world's largest laptop manufacturing base."
   },
@@ -16,12 +30,26 @@
     "Model Series": "Zbook Studio",
     "Generation": "G5",
     "Typical Final Assembly Location(s)": [
-        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "Chongqing, China",
+        "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Kunshan, China",
+        "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      }
     ],
     "Notes & Context": "At the time of the G5's production, Chongqing was solidifying its status as the world's largest laptop manufacturing base."
   },
@@ -29,13 +57,31 @@
     "Model Series": "Elitebook",
     "Generation": "G6",
     "Typical Final Assembly Location(s)": [
-        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "Chongqing, China",
+        "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Kunshan, China",
+        "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
-        {"name": "Wistron", "map_url": "https://www.wistron.com/en", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      },
+      {
+        "name": "Wistron",
+        "map_url": "https://maps.google.com/maps?q=Wistron&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"
+      }
     ],
     "Notes & Context": "Supply chains were heavily concentrated in mainland China. The G6 followed this established manufacturing footprint."
   },
@@ -43,13 +89,31 @@
     "Model Series": "Zbook Studio",
     "Generation": "G6",
     "Typical Final Assembly Location(s)": [
-        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "Chongqing, China",
+        "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Kunshan, China",
+        "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
-        {"name": "Wistron", "map_url": "https://www.wistron.com/en", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      },
+      {
+        "name": "Wistron",
+        "map_url": "https://maps.google.com/maps?q=Wistron&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"
+      }
     ],
     "Notes & Context": "Supply chains were heavily concentrated in mainland China. The G6 followed this established manufacturing footprint."
   },
@@ -57,13 +121,31 @@
     "Model Series": "Elitebook",
     "Generation": "G7",
     "Typical Final Assembly Location(s)": [
-        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "Chongqing, China",
+        "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Kunshan, China",
+        "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
-        {"name": "Wistron", "map_url": "https://www.wistron.com/en", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      },
+      {
+        "name": "Wistron",
+        "map_url": "https://maps.google.com/maps?q=Wistron&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"
+      }
     ],
     "Notes & Context": "Production continued in established Chinese industrial hubs. Minor disruptions began to appear due to early pandemic-related supply chain issues."
   },
@@ -71,13 +153,31 @@
     "Model Series": "Zbook Studio",
     "Generation": "G7",
     "Typical Final Assembly Location(s)": [
-        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "Chongqing, China",
+        "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Kunshan, China",
+        "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
-        {"name": "Wistron", "map_url": "https://www.wistron.com/en", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      },
+      {
+        "name": "Wistron",
+        "map_url": "https://maps.google.com/maps?q=Wistron&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Wistron_logo.svg"
+      }
     ],
     "Notes & Context": "Production continued in established Chinese industrial hubs. Minor disruptions began to appear due to early pandemic-related supply chain issues."
   },
@@ -85,12 +185,26 @@
     "Model Series": "Elitebook",
     "Generation": "G8",
     "Typical Final Assembly Location(s)": [
-        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "Chongqing, China",
+        "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Kunshan, China",
+        "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      }
     ],
     "Notes & Context": "The pandemic solidified the reliance on these large-scale manufacturing centers, even as global logistics became more complex."
   },
@@ -98,12 +212,26 @@
     "Model Series": "Zbook Studio",
     "Generation": "G8",
     "Typical Final Assembly Location(s)": [
-        {"name": "Chongqing, China", "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Kunshan, China", "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "Chongqing, China",
+        "map_url": "https://maps.google.com/maps?q=Chongqing,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Kunshan, China",
+        "map_url": "https://maps.google.com/maps?q=Kunshan,Suzhou,Jiangsu,China&t=&z=9&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      }
     ],
     "Notes & Context": "The pandemic solidified the reliance on these large-scale manufacturing centers, even as global logistics became more complex."
   },
@@ -111,13 +239,31 @@
     "Model Series": "Elitebook",
     "Generation": "G9",
     "Typical Final Assembly Location(s)": [
-        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "China",
+        "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Vietnam",
+        "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
-        {"name": "Foxconn", "map_url": "https://www.foxconn.com/en-us", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      },
+      {
+        "name": "Foxconn",
+        "map_url": "https://maps.google.com/maps?q=Foxconn&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"
+      }
     ],
     "Notes & Context": "HP began to diversify its assembly locations more significantly. While still primarily in China, some production shifted to Vietnam as part of a 'China +1' strategy."
   },
@@ -125,13 +271,31 @@
     "Model Series": "Zbook Studio",
     "Generation": "G9",
     "Typical Final Assembly Location(s)": [
-        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "China",
+        "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Vietnam",
+        "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
-        {"name": "Foxconn", "map_url": "https://www.foxconn.com/en-us", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      },
+      {
+        "name": "Foxconn",
+        "map_url": "https://maps.google.com/maps?q=Foxconn&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"
+      }
     ],
     "Notes & Context": "HP began to diversify its assembly locations more significantly. While still primarily in China, some production shifted to Vietnam as part of a 'China +1' strategy."
   },
@@ -139,14 +303,35 @@
     "Model Series": "Elitebook",
     "Generation": "G10",
     "Typical Final Assembly Location(s)": [
-        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Mexico", "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "China",
+        "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Vietnam",
+        "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Mexico",
+        "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
-        {"name": "Foxconn", "map_url": "https://www.foxconn.com/en-us", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      },
+      {
+        "name": "Foxconn",
+        "map_url": "https://maps.google.com/maps?q=Foxconn&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"
+      }
     ],
     "Notes & Context": "Diversification continues. Assembly in Mexico often serves the North American market more directly, reducing shipping times and tariffs."
   },
@@ -154,14 +339,35 @@
     "Model Series": "Zbook Studio",
     "Generation": "G10",
     "Typical Final Assembly Location(s)": [
-        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Mexico", "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "China",
+        "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Vietnam",
+        "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Mexico",
+        "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
-        {"name": "Foxconn", "map_url": "https://www.foxconn.com/en-us", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      },
+      {
+        "name": "Foxconn",
+        "map_url": "https://maps.google.com/maps?q=Foxconn&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"
+      }
     ],
     "Notes & Context": "Diversification continues. Assembly in Mexico often serves the North American market more directly, reducing shipping times and tariffs."
   },
@@ -169,15 +375,39 @@
     "Model Series": "Elitebook",
     "Generation": "G11",
     "Typical Final Assembly Location(s)": [
-        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Mexico", "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"},
-        {"name": "USA (Limited)", "map_url": "https://maps.google.com/maps?q=USA&t=&z=4&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "China",
+        "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Vietnam",
+        "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Mexico",
+        "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "USA (Limited)",
+        "map_url": "https://maps.google.com/maps?q=USA&t=&z=4&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
-        {"name": "Foxconn", "map_url": "https://www.foxconn.com/en-us", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      },
+      {
+        "name": "Foxconn",
+        "map_url": "https://maps.google.com/maps?q=Foxconn&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"
+      }
     ],
     "Notes & Context": "The trend of geographic diversification is most pronounced with the latest models. Limited final assembly or 'fulfillment' for specific large corporate or government orders may occur in the USA."
   },
@@ -185,15 +415,39 @@
     "Model Series": "Zbook Studio",
     "Generation": "G11",
     "Typical Final Assembly Location(s)": [
-        {"name": "China", "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Vietnam", "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"},
-        {"name": "Mexico", "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"},
-        {"name": "USA (Limited)", "map_url": "https://maps.google.com/maps?q=USA&t=&z=4&ie=UTF8&iwloc=&output=embed"}
+      {
+        "name": "China",
+        "map_url": "https://maps.google.com/maps?q=China&t=&z=5&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Vietnam",
+        "map_url": "https://maps.google.com/maps?q=Vietnam&t=&z=6&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "Mexico",
+        "map_url": "https://maps.google.com/maps?q=Mexico&t=&z=5&ie=UTF8&iwloc=&output=embed"
+      },
+      {
+        "name": "USA (Limited)",
+        "map_url": "https://maps.google.com/maps?q=USA&t=&z=4&ie=UTF8&iwloc=&output=embed"
+      }
     ],
     "Primary Assembly Partners (ODMs)": [
-        {"name": "Quanta Computer", "map_url": "https://www.quantatw.com/quanta/english/default.aspx", "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"},
-        {"name": "Compal Electronics", "map_url": "https://www.compal.com/en-us/", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"},
-        {"name": "Foxconn", "map_url": "https://www.foxconn.com/en-us", "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"}
+      {
+        "name": "Quanta Computer",
+        "map_url": "https://maps.google.com/maps?q=Quanta+Computer&output=embed",
+        "logo_url": "https://www.quantatw.com/quantatw/english/images/logo.png"
+      },
+      {
+        "name": "Compal Electronics",
+        "map_url": "https://maps.google.com/maps?q=Compal+Electronics&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/90/Compal_Electronics_logo.svg"
+      },
+      {
+        "name": "Foxconn",
+        "map_url": "https://maps.google.com/maps?q=Foxconn&output=embed",
+        "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Foxconn_logo.svg"
+      }
     ],
     "Notes & Context": "The trend of geographic diversification is most pronounced with the latest models. Limited final assembly or 'fulfillment' for specific large corporate or government orders may occur in the USA."
   }

--- a/pages/laptops.html
+++ b/pages/laptops.html
@@ -14,7 +14,6 @@
     <link rel="stylesheet" href="../css/styles.css">
     <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
- Updated all `map_url` links in `data/supply_chain.json` from direct corporate site URLs to embeddable Google Maps URLs (`https://maps.google.com/maps?q={query}&output=embed`).
- This fixes the `X-Frame-Options` and `connection refused` errors when rendering the supply chain map iframes.
- Fixed a minor CSS syntax error in `css/styles.css` where a closing brace was missing.
- Removed unused standalone Babel CDN script from `pages/laptops.html`.