### PR TITLE
Remove Fulfillment Associate role and rename Supply Chain section

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -10,7 +10,7 @@
         "url": "laptops.html"
     },
     {
-        "name": "Supply Chain",
+        "name": "Laptop Supply Chain",
         "description": "An overview of supply chain analysis and global logistics operations.",
         "url": "supply_chain.html"
     }

--- a/pages/disclaimer.html
+++ b/pages/disclaimer.html
@@ -63,8 +63,8 @@
                     <h3>6. API Usage</h3>
                     <p>The APIs integrated into the 'API Examples' page are used strictly for educational and demonstration purposes. No commercial use is intended with these APIs. Some data may be simulated or fetched from third-party services. We do not claim ownership of the data provided by these third-party services, and all rights belong to their respective owners.</p>
 
-                    <h3>7. Laptops Database and Supply Chain Analysis</h3>
-                    <p>The "Laptops Database" and "Supply Chain" pages contain mock data and embedded maps/information intended strictly for educational and portfolio demonstration purposes. The data, specifications, or corporate information displayed on these pages may not be accurate, current, or representative of actual real-world entities. They do not constitute financial, operational, or business advice.</p>
+                    <h3>7. Laptops Database and Laptop Supply Chain Analysis</h3>
+                    <p>The "Laptops Database" and "Laptop Supply Chain" pages contain mock data and embedded maps/information intended strictly for educational and portfolio demonstration purposes. The data, specifications, or corporate information displayed on these pages may not be accurate, current, or representative of actual real-world entities. They do not constitute financial, operational, or business advice.</p>
                 </section>
 
             </main>

--- a/pages/index.html
+++ b/pages/index.html
@@ -55,19 +55,6 @@
                             <p class="item-meta">Amazon Fulfillment Center</p>
                             <p class="item-description">Diagnosed and resolved complex IT issues while performing routine maintenance. Provided comprehensive user support and technical guidance.</p>
                         </div>
-                        <div class="timeline-item">
-                            <h3>Fulfillment Associate</h3>
-                            <p class="item-meta">Amazon Fulfillment Center</p>
-                            <div class="item-description">
-                                Processed orders in the following departments:
-                                <ul>
-                                    <li>Picking</li>
-                                    <li>Packing</li>
-                                    <li>Ship Dock</li>
-                                    <li>ICQA</li>
-                                </ul>
-                            </div>
-                        </div>
                     </div>
                 </section>
 

--- a/pages/supply_chain.html
+++ b/pages/supply_chain.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Marcos Alvarez | Supply Chain</title>
+    <title>Marcos Alvarez | Laptop Supply Chain</title>
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -41,7 +41,7 @@
             <main>
 
                 <section id="supply-chain">
-                    <h2 class="section-title">Supply Chain Analysis</h2>
+                    <h2 class="section-title">Laptop Supply Chain Analysis</h2>
                     <h3 class="section-title">HP EliteBook</h3>
                     <div id="elitebook-supply-chain-cards" class="card-grid"></div>
                     <h3 class="section-title">HP ZBook Studio</h3>


### PR DESCRIPTION
Removed the "Fulfillment Associate" role from the experience section on the main page. Additionally, renamed all occurrences of "Supply Chain" to "Laptop Supply Chain" across HTML pages and JSON configurations.

---
*PR created automatically by Jules for task [8257906694395774376](https://jules.google.com/task/8257906694395774376) started by @markmdagit*