### PR TITLE
feat: add theme toggle to all pages

### DIFF
--- a/pages/api-examples.html
+++ b/pages/api-examples.html
@@ -16,6 +16,7 @@
 
     <div class="container">
 
+        <button id="theme-toggle" class="theme-toggle-btn" title="Toggle Light/Dark Mode"><i class="fas fa-moon"></i></button>
         <header class="resume-header">
             <img src="../images/headshot.png" alt="Marcos Alvarez" class="profile-pic">
             <h1>Marcos Alvarez</h1>
@@ -260,5 +261,6 @@
     </div>
 
     <script src="../js/api-examples.js"></script>
+    <script src="../js/main.js"></script>
 </body>
 </html>

--- a/pages/disclaimer.html
+++ b/pages/disclaimer.html
@@ -17,6 +17,7 @@
 
     <div class="container">
 
+        <button id="theme-toggle" class="theme-toggle-btn" title="Toggle Light/Dark Mode"><i class="fas fa-moon"></i></button>
         <header class="resume-header">
             <img src="../images/headshot.png" alt="Marcos Alvarez" class="profile-pic">
             <h1>Marcos Alvarez</h1>

--- a/pages/laptops.html
+++ b/pages/laptops.html
@@ -19,6 +19,7 @@
 
     <div class="container">
 
+        <button id="theme-toggle" class="theme-toggle-btn" title="Toggle Light/Dark Mode"><i class="fas fa-moon"></i></button>
         <header class="resume-header">
             <img src="../images/headshot.png" alt="Marcos Alvarez" class="profile-pic">
             <h1>Marcos Alvarez</h1>

--- a/pages/supply_chain.html
+++ b/pages/supply_chain.html
@@ -17,6 +17,7 @@
 
     <div class="container">
 
+        <button id="theme-toggle" class="theme-toggle-btn" title="Toggle Light/Dark Mode"><i class="fas fa-moon"></i></button>
         <header class="resume-header">
             <img src="../images/headshot.png" alt="Marcos Alvarez" class="profile-pic">
             <h1>Marcos Alvarez</h1>


### PR DESCRIPTION
Added the light/dark mode theme toggle button to:
- pages/api-examples.html
- pages/laptops.html
- pages/supply_chain.html
- pages/disclaimer.html Imported main.js in these pages so the toggle functionality works.