### PR TITLE
Update experience section and titles to reflect IT Support role

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,7 +1,7 @@
 # AGENTS.md - Career Pivot Context: IT Support to Software Engineering
 
 ## Core Mission
-The primary goal of this project is to showcase the transition from **IT Support Associate II (8 years at Amazon)** to **Software Engineer/Computer Engineer**. The AI should prioritize engineering-heavy solutions over basic IT or simple web fixes.
+The primary goal of this project is to showcase the transition from **IT Support (8 years at Amazon)** to **Software Engineer/Computer Engineer**. The AI should prioritize engineering-heavy solutions over basic IT or simple web fixes.
 
 ## Tech Stack & Academic Context
 - **Current Education:** BS in Computer Engineering at CSUSB (In Progress). 

--- a/js/api-examples.js
+++ b/js/api-examples.js
@@ -3010,9 +3010,9 @@ class LinkedInProfileAPI {
         this.profileUrl = "https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/";
         this.data = {
             name: "Marcos Alvarez",
-            headline: "IT Support Associate II at Amazon Robotics Sort Center",
+            headline: "IT Support at Amazon Robotics Sort Center",
             location: "United States",
-            about: "IT Support Associate II with over 8 years of experience at Amazon. Currently pursuing a Bachelor of Science in Computer Science at CSUSB.",
+            about: "IT Support with over 8 years of experience at Amazon. Currently pursuing a Bachelor of Science in Computer Science at CSUSB.",
             connections: 500,
             avatar: "../images/headshot.png"
         };

--- a/pages/index.html
+++ b/pages/index.html
@@ -48,7 +48,7 @@
                     <h2 class="section-title">Professional Experience</h2>
                     <div class="timeline">
                         <div class="timeline-item">
-                            <h3>IT Support Associate II</h3>
+                            <h3>IT Support</h3>
                             <p class="item-meta">Amazon Robotics Sort Center</p>
                             <div class="item-description">
                                 <strong>Infrastructure & Operations Governance</strong><br>
@@ -66,11 +66,6 @@
                                 Managed vendor relationships and procurement pipelines, auditing complex technical quotes and coordinating external vendor deployments to optimize budget allocation for site hardware deployments.<br><br>
                                 Collaborated with cross-functional regional teams via synchronous and asynchronous communication channels to synchronize infrastructure deployment strategies and share cross-site engineering best practices.
                             </div>
-                        </div>
-                        <div class="timeline-item">
-                            <h3>IT Support Technician</h3>
-                            <p class="item-meta">Amazon Fulfillment Center</p>
-                            <p class="item-description">Diagnosed and resolved complex IT issues while performing routine maintenance. Provided comprehensive user support and technical guidance.</p>
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
- Renamed "IT Support Associate II" to "IT Support" across `pages/index.html`, `js/api-examples.js`, and `agents.md` to streamline the job title.
- Removed the separate "IT Support Technician" timeline item from the Experience section in `pages/index.html` to consolidate the role history.