### PR TITLE
Update PDF download buttons to use window.print

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -930,3 +930,33 @@ footer {
     padding-bottom: 0.5rem;
     border-bottom: 1px solid #4a4a4a;
 }
+
+/* --- Print Styles (for Save as PDF) --- */
+@media print {
+    body {
+        background-color: #fff !important;
+        color: #000 !important;
+    }
+    .container {
+        box-shadow: none !important;
+        border: none !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        width: 100% !important;
+        max-width: 100% !important;
+    }
+    #theme-toggle, .audio-log-btn, nav, footer, .controls {
+        display: none !important;
+    }
+    .social-links a {
+        display: none !important;
+    }
+    a {
+        text-decoration: none !important;
+        color: #000 !important;
+    }
+    /* Expand collapsibles for printing */
+    .league-section {
+        display: block !important;
+    }
+}

--- a/pages/api-examples.html
+++ b/pages/api-examples.html
@@ -25,7 +25,7 @@
             <div class="social-links">
                 <a href="https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/" target="_blank" rel="noopener noreferrer" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
                 <a href="https://github.com/markmdagit" target="_blank" rel="noopener noreferrer" title="GitHub"><i class="fab fa-github"></i></a>
-                <a href="../Marcos_Alvarez_Resume.pdf" download="Marcos_Alvarez_Resume.pdf" title="Download as PDF"><i class="fas fa-file-pdf"></i></a>
+                <a href="#" onclick="window.print(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
             </div>
         </header>
 

--- a/pages/disclaimer.html
+++ b/pages/disclaimer.html
@@ -26,7 +26,7 @@
             <div class="social-links">
                 <a href="https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
                 <a href="https://github.com/markmdagit" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
-                <a href="../Marcos_Alvarez_Resume.pdf" download="Marcos_Alvarez_Resume.pdf" title="Download as PDF"><i class="fas fa-file-pdf"></i></a>
+                <a href="#" onclick="window.print(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
             </div>
         </header>
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -25,7 +25,7 @@
             <div class="social-links">
                 <a href="https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/" target="_blank" rel="noopener noreferrer" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
                 <a href="https://github.com/markmdagit" target="_blank" rel="noopener noreferrer" title="GitHub"><i class="fab fa-github"></i></a>
-                <a href="../Marcos_Alvarez_Resume.pdf" download="Marcos_Alvarez_Resume.pdf" title="Download as PDF"><i class="fas fa-file-pdf"></i></a>
+                <a href="#" onclick="window.print(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
             </div>
             <button id="play-audio-log" class="audio-log-btn" style="margin-top: 1rem; padding: 0.5rem 1rem; cursor: pointer; background-color: #004A99; color: white; border: none; border-radius: 5px; font-size: 1rem;" title="Play Audio Summary">
                 <i class="fas fa-volume-up"></i> Play Audio Log

--- a/pages/laptops.html
+++ b/pages/laptops.html
@@ -28,7 +28,7 @@
             <div class="social-links">
                 <a href="https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
                 <a href="https://github.com/markmdagitboy" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
-                <a href="../Marcos_Alvarez_Resume.pdf" download="Marcos_Alvarez_Resume.pdf" title="Download as PDF"><i class="fas fa-file-pdf"></i></a>
+                <a href="#" onclick="window.print(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
             </div>
         </header>
 

--- a/pages/supply_chain.html
+++ b/pages/supply_chain.html
@@ -26,7 +26,7 @@
             <div class="social-links">
                 <a href="https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
                 <a href="https://github.com/markmdagitboy" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
-                <a href="../Marcos_Alvarez_Resume.pdf" download="Marcos_Alvarez_Resume.pdf" title="Download as PDF"><i class="fas fa-file-pdf"></i></a>
+                <a href="#" onclick="window.print(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
             </div>
         </header>
 


### PR DESCRIPTION
- Replaced the static file download link (`../Marcos_Alvarez_Resume.pdf`) in the PDF buttons across all HTML pages with `onclick="window.print(); return false;"`. This allows users to generate a dynamic, up-to-date PDF of the current page content via the browser's native print dialog.
- Added a `@media print` section to `css/styles.css` to hide unnecessary UI elements (navigation, footer, theme toggle, audio controls) and force print-friendly colors (black text on white background) to ensure the generated PDF is clean and professional.