### PR TITLE
Implement dynamic PDF resume generator

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -959,4 +959,35 @@ footer {
     .league-section {
         display: block !important;
     }
+
+    /* Specific styles for Resume Print Mode */
+    body.resume-print-mode > *:not(#resume-print-container) {
+        display: none !important;
+    }
+
+    #resume-print-container {
+        display: block !important;
+        width: 100%;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    #resume-print-container .timeline-item {
+        border-left: none;
+        padding-left: 0;
+        margin-bottom: 15px;
+    }
+
+    #resume-print-container .skills-grid {
+        display: block;
+    }
+
+    #resume-print-container .skill-card {
+        background: transparent;
+        border: none;
+        box-shadow: none;
+        padding: 0;
+        margin-bottom: 10px;
+    }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -28,6 +28,21 @@ document.addEventListener("DOMContentLoaded", () => {
     loadProjects();
     initAudioLog();
     initThemeToggle();
+
+    // Check if we need to auto-trigger the resume print
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('printResume') === 'true') {
+        // Wait a small amount for DOM/fonts to be ready, then print
+        setTimeout(() => {
+            if (typeof window.generateResumePDF === 'function') {
+                window.generateResumePDF();
+
+                // Remove the query parameter so refreshing doesn't keep printing
+                const newUrl = window.location.pathname;
+                window.history.replaceState({}, document.title, newUrl);
+            }
+        }, 500);
+    }
 });
 
 async function loadProjects() {
@@ -211,6 +226,76 @@ function createSupplyChainCard(container, item) {
         }
     }
     container.appendChild(card);
+}
+
+window.generateResumePDF = function() {
+    const printContent = document.createElement('div');
+    printContent.id = 'resume-print-container';
+
+    // Header
+    const header = document.createElement('div');
+    header.style.textAlign = 'center';
+    header.style.marginBottom = '20px';
+    header.style.borderBottom = '2px solid #333';
+    header.style.paddingBottom = '10px';
+
+    const name = document.createElement('h1');
+    name.textContent = 'Marcos Alvarez';
+    name.style.margin = '0';
+    name.style.fontSize = '24px';
+
+    const title = document.createElement('h2');
+    title.textContent = 'Information Systems & Technology | Business Intelligence & Analytics';
+    title.style.margin = '5px 0 0 0';
+    title.style.fontSize = '16px';
+    title.style.fontWeight = 'normal';
+    title.style.color = '#555';
+
+    header.appendChild(name);
+    header.appendChild(title);
+    printContent.appendChild(header);
+
+    // Ensure we are on the main page where these sections exist.
+    // If not, we could redirect or just tell the user, but for now, redirect to index.html and trigger print
+    if (!document.getElementById('experience')) {
+        // We aren't on index.html, redirect there and add a query parameter to print
+        window.location.href = 'index.html?printResume=true';
+        return;
+    }
+
+    // Extract Sections
+    const sectionsToExtract = ['experience', 'technologies', 'education'];
+
+    sectionsToExtract.forEach(sectionId => {
+        const originalSection = document.getElementById(sectionId);
+        if (originalSection) {
+            const clonedSection = originalSection.cloneNode(true);
+            clonedSection.style.marginBottom = '20px';
+
+            // Adjust styles for print (e.g., ensure text is dark, spacing is tight)
+            const headings = clonedSection.querySelectorAll('h2, h3');
+            headings.forEach(h => {
+                h.style.color = '#000';
+                h.style.marginTop = '10px';
+                h.style.marginBottom = '5px';
+            });
+
+            printContent.appendChild(clonedSection);
+        }
+    });
+
+    // We append the container to body, call print, then remove it
+    // To only print this container, we'll use CSS @media print
+    document.body.appendChild(printContent);
+
+    // Add a temporary class to body to hide everything else
+    document.body.classList.add('resume-print-mode');
+
+    window.print();
+
+    // Cleanup
+    document.body.classList.remove('resume-print-mode');
+    document.body.removeChild(printContent);
 }
 
 function initThemeToggle() {

--- a/pages/api-examples.html
+++ b/pages/api-examples.html
@@ -25,7 +25,7 @@
             <div class="social-links">
                 <a href="https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/" target="_blank" rel="noopener noreferrer" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
                 <a href="https://github.com/markmdagit" target="_blank" rel="noopener noreferrer" title="GitHub"><i class="fab fa-github"></i></a>
-                <a href="#" onclick="window.print(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
+                <a href="#" onclick="generateResumePDF(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
             </div>
         </header>
 

--- a/pages/disclaimer.html
+++ b/pages/disclaimer.html
@@ -26,7 +26,7 @@
             <div class="social-links">
                 <a href="https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
                 <a href="https://github.com/markmdagit" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
-                <a href="#" onclick="window.print(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
+                <a href="#" onclick="generateResumePDF(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
             </div>
         </header>
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -25,7 +25,7 @@
             <div class="social-links">
                 <a href="https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/" target="_blank" rel="noopener noreferrer" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
                 <a href="https://github.com/markmdagit" target="_blank" rel="noopener noreferrer" title="GitHub"><i class="fab fa-github"></i></a>
-                <a href="#" onclick="window.print(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
+                <a href="#" onclick="generateResumePDF(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
             </div>
             <button id="play-audio-log" class="audio-log-btn" style="margin-top: 1rem; padding: 0.5rem 1rem; cursor: pointer; background-color: #004A99; color: white; border: none; border-radius: 5px; font-size: 1rem;" title="Play Audio Summary">
                 <i class="fas fa-volume-up"></i> Play Audio Log

--- a/pages/laptops.html
+++ b/pages/laptops.html
@@ -28,7 +28,7 @@
             <div class="social-links">
                 <a href="https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
                 <a href="https://github.com/markmdagitboy" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
-                <a href="#" onclick="window.print(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
+                <a href="#" onclick="generateResumePDF(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
             </div>
         </header>
 

--- a/pages/supply_chain.html
+++ b/pages/supply_chain.html
@@ -26,7 +26,7 @@
             <div class="social-links">
                 <a href="https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
                 <a href="https://github.com/markmdagitboy" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
-                <a href="#" onclick="window.print(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
+                <a href="#" onclick="generateResumePDF(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
             </div>
         </header>
 


### PR DESCRIPTION
- Added `generateResumePDF()` to `js/main.js` to dynamically assemble a printable resume layout containing the "Professional Experience", "Technologies", and "Education" sections, complete with a custom header.
- Updated all PDF download buttons across the site to trigger `generateResumePDF()`.
- Implemented logic to handle clicks from non-index pages by redirecting to `index.html` with a `?printResume=true` parameter.
- Refined `@media print` CSS rules to hide non-essential elements and correctly format the dynamically created resume container.