### PR TITLE
Refine dynamic PDF generator for a traditional resume layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -968,26 +968,71 @@ footer {
     #resume-print-container {
         display: block !important;
         width: 100%;
-        max-width: 800px;
+        max-width: 8.5in; /* Standard letter size */
         margin: 0 auto;
-        padding: 20px;
+        padding: 0.5in;
+        font-family: Arial, Helvetica, sans-serif !important;
+        font-size: 11pt !important;
+        line-height: 1.3 !important;
+        color: #000 !important;
     }
 
-    #resume-print-container .timeline-item {
-        border-left: none;
-        padding-left: 0;
-        margin-bottom: 15px;
+    .resume-header-clean {
+        text-align: center;
+        margin-bottom: 0.25in;
+        border-bottom: 2px solid #000;
+        padding-bottom: 0.1in;
     }
 
-    #resume-print-container .skills-grid {
-        display: block;
+    .resume-header-clean h1 {
+        font-size: 24pt !important;
+        margin: 0 0 0.05in 0;
+        font-weight: bold;
     }
 
-    #resume-print-container .skill-card {
-        background: transparent;
-        border: none;
-        box-shadow: none;
+    .resume-header-clean p {
+        font-size: 11pt !important;
+        margin: 0;
+        color: #333 !important;
+    }
+
+    #resume-print-container h2 {
+        font-size: 14pt !important;
+        text-transform: uppercase;
+        border-bottom: 1px solid #000;
+        margin-top: 0.2in;
+        margin-bottom: 0.1in;
+        padding-bottom: 0.05in;
+        color: #000 !important;
+    }
+
+    #resume-print-container h3 {
+        font-size: 12pt !important;
+        margin: 0.1in 0 0.05in 0;
+        font-weight: bold;
+        color: #000 !important;
+    }
+
+    #resume-print-container p {
+        margin: 0 0 0.05in 0;
+    }
+
+    #resume-print-container ul {
+        margin: 0.05in 0 0.1in 0.2in;
         padding: 0;
-        margin-bottom: 10px;
+    }
+
+    #resume-print-container li {
+        margin-bottom: 0.05in;
+    }
+
+    /* Override grid/flex layouts */
+    #resume-print-container div,
+    #resume-print-container section,
+    #resume-print-container ul,
+    #resume-print-container li {
+        display: block !important;
+        width: auto !important;
+        float: none !important;
     }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -229,39 +229,28 @@ function createSupplyChainCard(container, item) {
 }
 
 window.generateResumePDF = function() {
+    // Ensure we are on the main page where these sections exist.
+    if (!document.getElementById('experience')) {
+        window.location.href = 'index.html?printResume=true';
+        return;
+    }
+
     const printContent = document.createElement('div');
     printContent.id = 'resume-print-container';
 
     // Header
     const header = document.createElement('div');
-    header.style.textAlign = 'center';
-    header.style.marginBottom = '20px';
-    header.style.borderBottom = '2px solid #333';
-    header.style.paddingBottom = '10px';
+    header.className = 'resume-header-clean';
 
     const name = document.createElement('h1');
     name.textContent = 'Marcos Alvarez';
-    name.style.margin = '0';
-    name.style.fontSize = '24px';
 
-    const title = document.createElement('h2');
+    const title = document.createElement('p');
     title.textContent = 'Information Systems & Technology | Business Intelligence & Analytics';
-    title.style.margin = '5px 0 0 0';
-    title.style.fontSize = '16px';
-    title.style.fontWeight = 'normal';
-    title.style.color = '#555';
 
     header.appendChild(name);
     header.appendChild(title);
     printContent.appendChild(header);
-
-    // Ensure we are on the main page where these sections exist.
-    // If not, we could redirect or just tell the user, but for now, redirect to index.html and trigger print
-    if (!document.getElementById('experience')) {
-        // We aren't on index.html, redirect there and add a query parameter to print
-        window.location.href = 'index.html?printResume=true';
-        return;
-    }
 
     // Extract Sections
     const sectionsToExtract = ['experience', 'technologies', 'education'];
@@ -270,14 +259,22 @@ window.generateResumePDF = function() {
         const originalSection = document.getElementById(sectionId);
         if (originalSection) {
             const clonedSection = originalSection.cloneNode(true);
-            clonedSection.style.marginBottom = '20px';
 
-            // Adjust styles for print (e.g., ensure text is dark, spacing is tight)
-            const headings = clonedSection.querySelectorAll('h2, h3');
-            headings.forEach(h => {
-                h.style.color = '#000';
-                h.style.marginTop = '10px';
-                h.style.marginBottom = '5px';
+            // Strip attributes from the section itself
+            clonedSection.removeAttribute('id');
+            clonedSection.removeAttribute('class');
+            clonedSection.removeAttribute('style');
+
+            // Strip attributes and remove icons from all children
+            const allElements = clonedSection.querySelectorAll('*');
+            allElements.forEach(el => {
+                el.removeAttribute('id');
+                el.removeAttribute('class');
+                el.removeAttribute('style');
+
+                if (el.tagName.toLowerCase() === 'i' || el.tagName.toLowerCase() === 'svg') {
+                    el.remove();
+                }
             });
 
             printContent.appendChild(clonedSection);


### PR DESCRIPTION
- Modified `generateResumePDF()` in `js/main.js` to deeply strip all CSS classes, IDs, and inline styles from the extracted DOM sections.
- Filtered out FontAwesome icons and SVGs from the extracted content to ensure a clean document.
- Overhauled `#resume-print-container` styles within `@media print` in `css/styles.css` to enforce standard resume formatting: Arial font, 11pt sizing, tight line heights, block-level alignment, and classic bordered section headers.