### PR TITLE
Add blank AWS Data Engineer project page

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -23,5 +23,10 @@
         "name": "Physics Art",
         "description": "A 2D physics simulation of colliding dots leaving continuous colorful traces on an HTML5 Canvas.",
         "url": "physicsart.html"
+    },
+    {
+        "name": "AWS Data Engineer Personal Project: Data Ingestion and Transformation Example",
+        "description": "A showcase of AWS data pipeline concepts.",
+        "url": "aws_data_engineer.html"
     }
 ]

--- a/pages/aws_data_engineer.html
+++ b/pages/aws_data_engineer.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AWS Data Engineer Project | Marcos Alvarez</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+
+    <link rel="stylesheet" href="../css/styles.css">
+</head>
+<body>
+
+    <div class="container">
+
+        <button id="theme-toggle" class="theme-toggle-btn" title="Toggle Light/Dark Mode"><i class="fas fa-moon"></i></button>
+        <header class="resume-header">
+            <img src="../images/headshot.png" alt="Marcos Alvarez" class="profile-pic">
+            <h1>Marcos Alvarez</h1>
+            <p class="job-title">Information Systems &amp; Tech | Business Intelligence &amp; Analytics</p>
+            <p class="core-focus" style="margin-top: 0.5rem; font-size: 0.9rem; color: #a0a0a0;">Core Focus: Data Modeling, IT Infrastructure Automation, and Analytical Pipelines.</p>
+            <div class="social-links">
+                <a href="https://www.linkedin.com/in/marcos-alvarez-ab2ba5109/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
+                <a href="https://github.com/markmdagit" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
+                <a href="#" onclick="generateResumePDF(); return false;" title="Print/Save as PDF"><i class="fas fa-file-pdf"></i></a>
+            </div>
+        </header>
+
+        <nav>
+            <ul>
+                <li><a href="index.html#experience"><i class="fas fa-briefcase"></i> Experience</a></li>
+                <li><a href="index.html#education"><i class="fas fa-user-graduate"></i> Education</a></li>
+                <li><a href="index.html#projects"><i class="fas fa-tasks"></i> Projects</a></li>
+            </ul>
+        </nav>
+
+        <div class="content-wrapper">
+            <main>
+                <section>
+                    <h2 class="section-title">AWS Data Engineer Personal Project: Data Ingestion and Transformation Example</h2>
+                    <!-- Content will be added here later -->
+                </section>
+            </main>
+
+            <footer>
+                <p>&lt;/&gt; Built with Jules by Google</p>
+            </footer>
+        </div>
+
+    </div>
+
+    <script src="../js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
- Created `pages/aws_data_engineer.html` with standard site headers, nav, and styling.
- Left the `<main>` content section blank to be populated later.
- Added an entry for the project in `data/projects.json` so it automatically populates in the Projects carousel on the index page.